### PR TITLE
fix crash on GET /

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -129,7 +129,7 @@ var API = module.exports = function (opts) {
         next();
     });
     server.on('after', function (req, res, route, err) {
-        if (!EVT_SKIP_ROUTES[req.route.name]) {
+        if (req.route && !EVT_SKIP_ROUTES[req.route.name]) {
             req.trace.end(req.route.name);
         }
     });


### PR DESCRIPTION
this fixes

```
$ node bin/workflow-api c.json | bunyan
[2015-06-03T18:05:02.342Z]  INFO: workflow-api/18307 on joyadmins-MacBook-Pro.local: API backend initialized
[2015-06-03T18:05:02.353Z]  INFO: workflow-api/18307 on joyadmins-MacBook-Pro.local: WorkflowAPI listening at http://:::8080
[2015-06-03T18:05:02.354Z]  INFO: workflow-api/18307 on joyadmins-MacBook-Pro.local: API server up and running!
/Users/dave.eddy/dev/node-workflow/lib/api.js:132
        if (!EVT_SKIP_ROUTES[req.route.name]) {
                                      ^
TypeError: Cannot read property 'name' of undefined
    at Server.<anonymous> (/Users/dave.eddy/dev/node-workflow/lib/api.js:132:39)
    at Server.emit (events.js:129:20)
    at emitRouteError (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/server.js:152:24)
    at onRoute (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/server.js:623:33)
    at Router.find (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/router.js:473:9)
    at Server._route (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/server.js:617:21)
    at routeAndRun (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/server.js:576:22)
    at Server._handle (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/server.js:596:17)
    at Server.onRequest (/Users/dave.eddy/dev/node-workflow/node_modules/restify/lib/server.js:258:22)
    at Server.emit (events.js:110:17)
```